### PR TITLE
Add fixed alias for production builds

### DIFF
--- a/now.json
+++ b/now.json
@@ -1,6 +1,7 @@
 {
   "version": 2,
   "name": "github-issue-search-client",
+  "alias": "silverstripe-github-issues.now.sh",
   "build": {
     "env": {
       "VUE_APP_GRAPHQL_ENDPOINT": "https://api.github.com",


### PR DESCRIPTION
To ensure that the production URL for Now is always the same.