### PR TITLE
Google Analytics (fixes #39)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -13,5 +13,15 @@
     </noscript>
     <div id="app"></div>
     <!-- built files will be auto injected -->
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-84547-17"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() { dataLayer.push(arguments); }
+      gtag('js', new Date());
+
+      gtag('config', 'UA-84547-17');
+    </script>
+
   </body>
 </html>


### PR DESCRIPTION
We can be smarter about not hardcoding the GA tracking code,
but for now let's just get the thing going.
It's tracking on the main silverstripe.org account,
which already has cross-domain tracking set up.
This enables us e.g. to determine how many people
are using this tool based on reading our "contributing code" instructions.