### PR TITLE
FIX Remove duplicate repositories from the list. Also updates readme and supported modules file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,14 @@ npm run build
 
 ## Deploy
 
-The project is published to [Now](https://zeit.co/now). To do this you will need to have the Now CLI installed, be
+### Continuous deployment
+
+The project is published to [Now](https://zeit.co/now) automatically when changes are merged into the master branch.
+This is done via an automatic GitHub integration.
+
+### Manual deployment
+
+You can also deploy projects manually. To do this you will need to have the Now CLI installed, be
 logged in, part of the SilverStripe team, and have the team configured in your profile. For access to the team,
 contact internally.
 

--- a/src/components/SearchResults.vue
+++ b/src/components/SearchResults.vue
@@ -125,11 +125,12 @@ export default {
       // TODO Pass this through main.js as props
       const ids = this.includeSupported ? supportedGroups : coreGroups;
 
-      return this.repoGroups
+      const repos = this.repoGroups
         .filter(repoGroup => ids.includes(repoGroup.id))
-        .reduce((repos, repoGroup) => repos.concat(repoGroup.repos), [])
-        .map(repo => `repo:${repo}`)
-        .join(' ');
+        .reduce((repos, repoGroup) => repos.concat(repoGroup.repos), []);
+      const uniqueRepos = [...new Set(repos)]; // filter out duplicates
+
+      return uniqueRepos.map(repo => `repo:${repo}`).join(' ');
     },
 
     /**

--- a/src/repos.json
+++ b/src/repos.json
@@ -127,7 +127,12 @@
       "symbiote/silverstripe-advancedworkflow",
       "symbiote/silverstripe-multivaluefield",
       "symbiote/silverstripe-queuedjobs",
-      "symbiote/silverstripe-versionedfiles"
+      "symbiote/silverstripe-versionedfiles",
+      "silverstripe/silverstripe-mfa",
+      "silverstripe/silverstripe-totp-authenticator",
+      "silverstripe/silverstripe-webauthn-authenticator",
+      "silverstripe/silverstripe-login-forms",
+      "silverstripe/silverstripe-security-extensions"
     ]
   },
   {
@@ -240,7 +245,12 @@
       "symbiote/silverstripe-advancedworkflow",
       "symbiote/silverstripe-multivaluefield",
       "symbiote/silverstripe-queuedjobs",
-      "symbiote/silverstripe-versionedfiles"
+      "symbiote/silverstripe-versionedfiles",
+      "silverstripe/silverstripe-mfa",
+      "silverstripe/silverstripe-totp-authenticator",
+      "silverstripe/silverstripe-webauthn-authenticator",
+      "silverstripe/silverstripe-login-forms",
+      "silverstripe/silverstripe-security-extensions"
     ]
   }
 ]

--- a/util/get-supported-module-env.js
+++ b/util/get-supported-module-env.js
@@ -62,8 +62,9 @@ const coreProductTeamRepos = [
   'silverstripe/silverstripe-versioned',
   'silverstripe/silverstripe-versioned-admin',
   'silverstripe/vendor-plugin',
-  'silverstripe/webpack-config'
-]
+  'silverstripe/webpack-config',
+];
+
 request(URL, function (error, response, body) {
   const modules = JSON.parse(body);
   const repos = modules.filter(module => module.type === 'supported-module').map(module => module.github);


### PR DESCRIPTION
* Remove duplicate repos before sending off to GitHub API
* Update readme notes around deployment, mentioning the automatic CD option via GitHub
* Update the list of supported modules (build via `npm run get-repos`)
* Some minor formatting changes

Fixes #52