### PR TITLE
NEW Add sorting field + misc improvements

### DIFF
--- a/src/apollo.js
+++ b/src/apollo.js
@@ -1,3 +1,4 @@
+/* global process */
 import { ApolloClient } from "apollo-client";
 import { HttpLink } from "apollo-link-http";
 import { InMemoryCache } from "apollo-cache-inmemory";

--- a/src/components/SearchResults.vue
+++ b/src/components/SearchResults.vue
@@ -21,10 +21,19 @@
               Include <a href="https://www.silverstripe.org/software/addons/silverstripe-commercially-supported-module-list/" target="_blank" rel="noopener">supported modules</a>
             </span>
           </label>
+
           <select id="issue-status" v-model="issueStatus" aria-label="Issue status" class="option-filter" @change="setIssueStatus()">
             <option value="open">Open issues</option>
             <option value="closed">Closed issues</option>
             <option value="all">Open and closed</option>
+          </select>
+
+          <select id="sort" v-model="sort" aria-label="Sort issues by" class="option-filter" @change="setIssueSort()">
+            <option value="">Best Match</option>
+            <option value="updated">Recently Updated</option>
+            <option value="updated-asc">Least Recently Updated</option>
+            <option value="created">Newest</option>
+            <option value="created-asc">Oldest</option>
           </select>
         </div>
         <ul class="tabs">
@@ -94,6 +103,7 @@ export default {
       includeSupported: searchParams.get('supported') !== '0',
       productTeamMode: searchParams.get('product-team-mode') === '1',
       issueStatus: searchParams.get('status') || 'open',
+      sort: searchParams.get('sort') || '',
       loading: 0,
       totalCount: 0,
       allResults: [],
@@ -142,6 +152,10 @@ export default {
       return uniqueRepos.map(repo => `repo:${repo}`).join(' ');
     },
 
+    sortQuery() {
+        return this.sort ? `sort:${this.sort}` : '';
+    },
+
     /**
      * Returns a query component for filtering issues by their open/closed status. Defaults to
      * only including open issues.
@@ -163,6 +177,7 @@ export default {
           ${this.statusQuery}
           is:issue
           ${this.repoQuery}
+          ${this.sortQuery}
         `;
     },
 
@@ -191,6 +206,9 @@ export default {
     },
     setIssueStatus() {
       this.updateURLWithParam('status', this.issueStatus);
+    },
+    setIssueSort() {
+      this.updateURLWithParam('sort', this.sort);
     },
     getMoreResults() {
       this.$apollo.queries.allResults.fetchMore({

--- a/src/components/SearchResults.vue
+++ b/src/components/SearchResults.vue
@@ -113,7 +113,7 @@ export default {
         rfc: 'RFC', // search term
         easy: 'label:effort/easy',
         bugs: 'label:type/bug',
-        untriaged: 'is:open is:issue -label:Epic -label:type/docs -label:type/ux -label:type/bug -label:type/enhancement -label:effort/easy -label:effort/medium -label:effort/hard -label:impact/critical -label:impact/high -label:impact/medium -label:impact/low -label:rfc/draft -label:rfc/accepted',
+        untriaged: 'is:open is:issue -label:Epic -label:type/docs -label:type/ux -label:type/bug -label:type/enhancement -label:effort/easy -label:effort/medium -label:effort/hard -label:impact/critical -label:impact/high -label:impact/medium -label:impact/low -label:rfc/draft -label:rfc/accepted -label:feedback-required/author',
       };
 
       return queryModes[this.mode] || '';

--- a/src/components/SearchResults.vue
+++ b/src/components/SearchResults.vue
@@ -58,7 +58,7 @@
 
     <!-- Result -->
     <div v-else-if="allResults.edges.length > 0" class="results apollo">
-      <h3 class="results__title">Search results</h3>
+      <h3 class="results__title">Search results ({{totalCount}} issues found)</h3>
       <ul class="results__list">
         <SearchResult v-for="issue in allResults.edges" :key="issue.id" :issue-data="issue" />
       </ul>

--- a/src/components/SearchResults.vue
+++ b/src/components/SearchResults.vue
@@ -121,6 +121,7 @@ export default {
 
     repoQuery() {
       if (!this.repoGroups) {
+        // eslint-disable-next-line
         console.error('Repository groups were not defined!');
       }
 

--- a/src/vue-apollo.js
+++ b/src/vue-apollo.js
@@ -1,3 +1,4 @@
+/* global process */
 import Vue from "vue";
 import VueApollo from "vue-apollo";
 import createApolloClient from "./apollo";


### PR DESCRIPTION
This PR:

- Adds a new field to select the sort order of the results, with options for Updated/Created ASC/DESC (and Best Match as the default)
- Adds the result count to the heading, for improved visibility
- Adds `feedback-required/author` to the Triage filter, as issues that have this tag generally aren't ready to be triaged
- Fixes some tiny linting failures