### PR TITLE
Accept customUrls param

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,3 +107,23 @@ the app can be run in a "team mode" through a URL parameter:
 `?product-team-mode=1`
 
 This will cause different repos to be included in the requests to Github.
+
+### Custom Repositories
+
+You can pass in a custom list of repositories via URL params:
+
+`?customRepos=silverstripe/silverstripe-framework,silverstripe/silverstripe-cms`
+
+This can be helpful to filter only to repos you're interested on in a specific project context,
+e.g. extracting them from your composer.lock file.
+
+Protip: You can generate these custom repos from your `composer.lock` file automatically
+through [Silverstripe Module Issue Browser Util](https://github.com/silverstripe/silverstripe-github-issue-search-composer-util).
+
+Assuming you've got your Composer binaries [set up globally](https://stackoverflow.com/questions/25373188/how-to-place-the-composer-vendor-bin-directory-in-your-path),
+the following will read from your lock file and open the issue browser:
+
+```
+composer global require silverstripe/github-issue-search-composer-util
+cat /my/project/composer.lock | github-issue-search | xargs open
+```

--- a/src/components/SearchResults.vue
+++ b/src/components/SearchResults.vue
@@ -337,7 +337,7 @@ export default {
   .form {
     background-color: #eef0f4;
     border-radius: 6px 6px 0 0;
-    color: #8F9FBA;
+    color: #43536D;
     font-family: "Helvetica Neue", sans-serif;
     margin-bottom: 40px;
     padding: 18px 20px 0 20px;

--- a/src/components/SearchResults.vue
+++ b/src/components/SearchResults.vue
@@ -12,7 +12,10 @@
           <input type="submit" class="submit" @click.prevent="onClick" value="Search" />
         </div>
         <div class="options">
-          <label class="option-filter">
+          <span class="option-filter" v-if="customRepos.length">
+            Filtering by {{customRepos.length}} repos
+          </span>
+          <label class="option-filter" v-else>
             <input type="checkbox" id="supported-modules" v-model="includeSupported" @change="setSupportedModules()">
             <span v-if="productTeamMode">
               Only <a href="https://www.silverstripe.org/software/addons/silverstripe-commercially-supported-module-list/" target="_blank" rel="noopener">supported modules</a>
@@ -110,6 +113,7 @@ export default {
       query: searchParams.get('q') || '',
       submitQuery: searchParams.get('q') || '',
       mode: searchParams.get('mode') || '',
+      customRepos: searchParams.get('customRepos') ? searchParams.get('customRepos').split(',') : [],
       includeSupported: searchParams.get('supported') !== '0',
       productTeamMode: searchParams.get('product-team-mode') === '1',
       issueStatus: searchParams.get('status') || 'open',
@@ -155,9 +159,15 @@ export default {
       // TODO Pass this through main.js as props
       const ids = this.includeSupported ? supportedGroups : coreGroups;
 
-      const repos = this.repoGroups
-        .filter(repoGroup => ids.includes(repoGroup.id))
-        .reduce((repos, repoGroup) => repos.concat(repoGroup.repos), []);
+      const repos = this.customRepos.length ?
+        // Pass in custom list of repos through the URL.
+        // This allows repos which aren't in any repo group, so could technically  be used
+        // for topics other than Silverstripe modules.
+        this.customRepos :
+        // Or determine it based on the UI SELECTIONS
+        this.repoGroups
+          .filter(repoGroup => ids.includes(repoGroup.id))
+          .reduce((repos, repoGroup) => repos.concat(repoGroup.repos), []);
       const uniqueRepos = [...new Set(repos)]; // filter out duplicates
 
       return uniqueRepos.map(repo => `repo:${repo}`).join(' ');

--- a/src/components/SearchResults.vue
+++ b/src/components/SearchResults.vue
@@ -73,8 +73,8 @@
     <!-- Result -->
     <div v-else-if="allResults.edges.length > 0" class="results apollo">
       <h3 class="results__title">
-        Search results (
-        {{totalCount}} 
+        Search results
+        ({{totalCount}}
         {{issueType === 'pr' ? 'pull request' : 'issue'}}{{totalCount > 1 ? 's' : ''}}
         found)
       </h3>


### PR DESCRIPTION
This technically circumvents the whitelist set through repos.json, and
could be used as a general purpose issue browser for Github. I think the
risk of that is reasonably low though, the Github token doesn't allow any
more access without this whitelist protection.